### PR TITLE
Silabos y Plan de Sesiones

### DIFF
--- a/AppSilaboAsistencia/CapaDatos/D_Catalogo.cs
+++ b/AppSilaboAsistencia/CapaDatos/D_Catalogo.cs
@@ -97,7 +97,7 @@ namespace CapaDatos
         }
 
         // Método para buscar los silabos de una asignatura.
-        public DataTable BuscarSilabosAsignatura(string CodSemestre, string CodAsignatura)
+        public DataTable BuscarSilabosAsignatura(string CodAsignatura)
         {
             DataTable Resultado = new DataTable();
             SqlCommand Comando = new SqlCommand("spuBuscarSilabosAsignatura", Conectar)
@@ -105,7 +105,6 @@ namespace CapaDatos
                 CommandType = CommandType.StoredProcedure
             };
 
-            Comando.Parameters.AddWithValue("@CodSemestre", CodSemestre);
             Comando.Parameters.AddWithValue("@CodAsignatura", CodAsignatura);
             SqlDataAdapter Data = new SqlDataAdapter(Comando); 
             Data.Fill(Resultado);
@@ -113,7 +112,7 @@ namespace CapaDatos
         }
 
         // Método para buscar los planes de sesión de una asignatura.
-        public DataTable BuscarPlanSesionesAsignatura(string CodSemestre, string CodAsignatura, string CodDocente)
+        public DataTable BuscarPlanSesionesAsignatura(string CodAsignatura, string CodDocente)
         {
             DataTable Resultado = new DataTable();
             SqlCommand Comando = new SqlCommand("spuBuscarPlanSesionesAsignatura", Conectar)
@@ -121,7 +120,6 @@ namespace CapaDatos
                 CommandType = CommandType.StoredProcedure
             };
 
-            Comando.Parameters.AddWithValue("@CodSemestre", CodSemestre);
             Comando.Parameters.AddWithValue("@CodAsignatura", CodAsignatura);
             Comando.Parameters.AddWithValue("@CodDocente", CodDocente);
             SqlDataAdapter Data = new SqlDataAdapter(Comando);

--- a/AppSilaboAsistencia/CapaNegocios/N_Catalogo.cs
+++ b/AppSilaboAsistencia/CapaNegocios/N_Catalogo.cs
@@ -33,14 +33,14 @@ namespace CapaNegocios
             return new D_Catalogo().BuscarAsignaturasAsignadasDocente(CodSemestre, CodDepartamentoA, CodDocente, Texto);
         }
 
-        public static DataTable BuscarSilabosAsignatura(string CodSemestre, string CodAsignatura)
+        public static DataTable BuscarSilabosAsignatura(string CodAsignatura)
         {
-            return new D_Catalogo().BuscarSilabosAsignatura(CodSemestre, CodAsignatura);
+            return new D_Catalogo().BuscarSilabosAsignatura(CodAsignatura);
         }
 
-        public static DataTable BuscarPlanSesionesAsignatura(string CodSemestre, string CodAsignatura, string CodDocente)
+        public static DataTable BuscarPlanSesionesAsignatura(string CodAsignatura, string CodDocente)
         {
-            return new D_Catalogo().BuscarPlanSesionesAsignatura(CodSemestre, CodAsignatura, CodDocente);
+            return new D_Catalogo().BuscarPlanSesionesAsignatura(CodAsignatura, CodDocente);
         }
         public static DataTable RecuperarPlanDeSesionAsignatura(string CodSemestre, string CodAsignatura, string CodDocente)
         {

--- a/AppSilaboAsistencia/CapaPresentaciones/App.config
+++ b/AppSilaboAsistencia/CapaPresentaciones/App.config
@@ -6,7 +6,7 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
     <connectionStrings>
-      <add name="Conexion" connectionString="Server=(local);Database=BDSistemaGestion;Trusted_Connection=True;" />
+      <add name="Conexion" connectionString="Server=localhost\SQLEXPRESS;Database=BDSistemaGestion;Trusted_Connection=True;" />
     </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/AppSilaboAsistencia/CapaPresentaciones/P_TablaAsignaturasAsignadasSesiones.cs
+++ b/AppSilaboAsistencia/CapaPresentaciones/P_TablaAsignaturasAsignadasSesiones.cs
@@ -99,7 +99,7 @@ namespace CapaPresentaciones
                 // Completar información
 
                 // Nombre y código del curso
-                wb.Worksheet(1).Cell("A3").Value = dtDatosAsignatura.Rows[0]["NombreAsignatura"].ToString() + " (" + CodAsignatura.Substring(0, 5) + ")";
+                wb.Worksheet(1).Cell("A3").Value = dtDatosAsignatura.Rows[0]["NombreAsignatura"].ToString() + " (" + CodAsignatura + ")";
 
                 // Semestre
                 wb.Worksheet(1).Cell("A4").Value = wb.Worksheet(1).Cell("A4").Value + "2021-II";

--- a/AppSilaboAsistencia/CapaPresentaciones/P_TablaSesionesAsignatura.cs
+++ b/AppSilaboAsistencia/CapaPresentaciones/P_TablaSesionesAsignatura.cs
@@ -23,7 +23,7 @@ namespace CapaPresentaciones
             this.CodAsignatura = CodAsignatura;
             InitializeComponent();
             Bunifu.Utils.DatagridView.BindDatagridViewScrollBar(dgvDatos, sbDatos);
-            Asignaturas = N_Catalogo.BuscarPlanSesionesAsignatura("2021-II", CodAsignatura.Substring(0, 5), "65475");
+            Asignaturas = N_Catalogo.BuscarPlanSesionesAsignatura(CodAsignatura.Substring(0, 5), "65475");
             MostrarAsignaturas();
         }
 

--- a/AppSilaboAsistencia/CapaPresentaciones/P_TablaSilabosAsignatura.cs
+++ b/AppSilaboAsistencia/CapaPresentaciones/P_TablaSilabosAsignatura.cs
@@ -23,7 +23,7 @@ namespace CapaPresentaciones
             this.CodAsignatura = CodAsignatura;
             InitializeComponent();
             Bunifu.Utils.DatagridView.BindDatagridViewScrollBar(dgvDatos, sbDatos);
-            Asignaturas = N_Catalogo.BuscarSilabosAsignatura("2021-II", CodAsignatura.Substring(0, 5));
+            Asignaturas = N_Catalogo.BuscarSilabosAsignatura(CodAsignatura.Substring(0, 5));
             MostrarAsignaturas();
         }
 

--- a/Script Base de Datos/BD_SilaboAsistencia.sql
+++ b/Script Base de Datos/BD_SilaboAsistencia.sql
@@ -1024,8 +1024,7 @@ END;
 GO
 
 -- Procedimiento para buscar los silabos de una asignatura.
-CREATE PROCEDURE spuBuscarSilabosAsignatura @CodSemestre VARCHAR(7),
-											@CodAsignatura VARCHAR(6)
+CREATE PROCEDURE spuBuscarSilabosAsignatura @CodAsignatura VARCHAR(6)
 AS
 BEGIN
 	-- Mostrar los silabos
@@ -1033,14 +1032,12 @@ BEGIN
 	                CodAsignatura = C.CodAsignatura + C.Grupo + C.CodEscuelaP, C.Silabo
 		FROM TCatalogo C INNER JOIN TDocente D ON
 			 C.CodDocente = D.CodDocente
-		WHERE C.CodSemestre = @CodSemestre AND C.CodAsignatura = @CodAsignatura AND 
-				C.Silabo IS NOT NULL
+		WHERE C.CodAsignatura = @CodAsignatura AND C.Silabo IS NOT NULL
 END;
 GO
 
--- Procedimiento para buscar los planes de sesión anteriores de un docente que dicto una asignatura.
-CREATE PROCEDURE spuBuscarPlanSesionesAsignatura @CodSemestre VARCHAR(7),
-											     @CodAsignatura VARCHAR(6),
+-- Procedimiento para buscar los planes de sesión anteriores de un docente que dictó una asignatura.
+CREATE PROCEDURE spuBuscarPlanSesionesAsignatura @CodAsignatura VARCHAR(6),
 											     @CodDocente VARCHAR(5)
 AS
 BEGIN
@@ -1049,13 +1046,13 @@ BEGIN
 	                CodAsignatura = C.CodAsignatura + C.Grupo + C.CodEscuelaP, C.PlanSesiones
 		FROM TCatalogo C INNER JOIN TDocente D ON
 			 C.CodDocente = D.CodDocente
-		WHERE C.CodSemestre = @CodSemestre AND C.CodAsignatura = @CodAsignatura AND 
+		WHERE C.CodAsignatura = @CodAsignatura AND 
 		      C.CodDocente = @CodDocente AND C.PlanSesiones IS NOT NULL
 END;
 GO
--- Procedimiento para recueprar un plan de sesión anteriores de un docente determinado.
+-- Procedimiento para recuperar un plan de sesión de un docente determinado.
 CREATE PROCEDURE spuRecuperarPlanSesionAsignatura @CodSemestre VARCHAR(7),
-											     @CodAsignatura VARCHAR(8),--codigo completo
+											     @CodAsignatura VARCHAR(8), -- código completo
 											     @CodDocente VARCHAR(5)
 AS
 BEGIN
@@ -1064,7 +1061,7 @@ BEGIN
 	                CodAsignatura = C.CodAsignatura + C.Grupo + C.CodEscuelaP, C.PlanSesiones
 		FROM TCatalogo C INNER JOIN TDocente D ON
 			 C.CodDocente = D.CodDocente
-		WHERE C.CodSemestre = @CodSemestre AND C.CodAsignatura+c.Grupo+c.CodEscuelaP = @CodAsignatura AND 
+		WHERE C.CodSemestre = @CodSemestre AND C.CodAsignatura + C.Grupo + C.CodEscuelaP = @CodAsignatura AND 
 		      C.CodDocente = @CodDocente AND C.PlanSesiones IS NOT NULL
 END;
 GO


### PR DESCRIPTION
Quitar el atributo CodSemestre para descargar anteriores.
Mostrar código completo en el autocompletado de la plantilla del plan de sesiones